### PR TITLE
vuepress-plugin-component-catalog

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -46,6 +46,8 @@ module.exports = {
   plugins: [
     ['@vuepress/back-to-top'],
 
+    ['component-catalog'],
+
     ['keyboard-event-debug'],
   ],
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -49,6 +49,8 @@ module.exports = {
 
     ['component-catalog', {
       distDirPrefix: 'misc/components',
+      include: [],
+      exclude: [],
     }],
 
     ['keyboard-event-debug'],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -37,6 +37,7 @@ module.exports = {
         title: '未分類',
         collapsable: false,
         children: [
+          '/misc/components/',
           '/misc/keyboard_event.md',
         ],
       },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -46,7 +46,9 @@ module.exports = {
   plugins: [
     ['@vuepress/back-to-top'],
 
-    ['component-catalog'],
+    ['component-catalog', {
+      distDirPrefix: 'misc/components',
+    }],
 
     ['keyboard-event-debug'],
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11195,6 +11195,84 @@
         }
       }
     },
+    "vuepress-plugin-component-catalog": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-component-catalog/-/vuepress-plugin-component-catalog-0.6.7.tgz",
+      "integrity": "sha512-vc03TOnWvLjS1gtIdH3Bq7JCHY0ZQR4v6Y3pQnoeP8YdhjXnr5FsVvfctbiAVcGCBMwXkMNQjyrc/b6kBSiQ7A==",
+      "dev": true,
+      "requires": {
+        "@vue/component-compiler-utils": "^2.6.0",
+        "chokidar": "^2.0.4",
+        "consola": "^2.3.0",
+        "express": "^4.16.4",
+        "minimatch": "^3.0.4",
+        "vue-template-compiler": "^2.5.17"
+      },
+      "dependencies": {
+        "@vue/component-compiler-utils": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
+          "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
+          "dev": true,
+          "requires": {
+            "consolidate": "^0.15.1",
+            "hash-sum": "^1.0.2",
+            "lru-cache": "^4.1.2",
+            "merge-source-map": "^1.1.0",
+            "postcss": "^7.0.14",
+            "postcss-selector-parser": "^5.0.0",
+            "prettier": "1.16.3",
+            "source-map": "~0.6.1",
+            "vue-template-es2015-compiler": "^1.9.0"
+          }
+        },
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "prettier": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+          "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
     "vuepress-plugin-container": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-container/-/vuepress-plugin-container-2.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "http-server": "^14.0.0",
     "sprintf-js": "^1.1.2",
     "vuepress": "^1.9.5",
+    "vuepress-plugin-component-catalog": "^0.6.7",
     "vuepress-plugin-keyboard-event-debug": "^1.0.1",
     "vuepress-types": "^0.9.4"
   },


### PR DESCRIPTION
## npm

https://www.npmjs.com/package/vuepress-plugin-component-catalog


## Note

Document can be written inside of SFC as `<docs>` block.

Because of default ignore config, we cannot list components under `docs/.vuepress/components` to the catalog.