### PR TITLE
Release diary plugin - inject back links in release note page

### DIFF
--- a/docs/.vuepress/plugins/playground-release-diary/components/PlaygroundReleaseDiaryBackLink.vue
+++ b/docs/.vuepress/plugins/playground-release-diary/components/PlaygroundReleaseDiaryBackLink.vue
@@ -1,0 +1,78 @@
+<template>
+  <div v-if="shouldShow">
+    <hr>
+    <ul>
+      <li>Back to <a :href="linkToDate">Release list ({{ date }})</a></li>
+      <li>Back to <a :href="linkToName">Release list ({{ name }})</a></li>
+    </ul>
+  </div>
+</template>
+
+<script>
+/**
+ * @typedef {import('vuepress-types').Page} Page
+ */
+
+import { sprintf } from 'sprintf-js';
+
+export default {
+  data() {
+    return {
+      shouldShow: false,
+      date: '',
+      name: '',
+      linkToDate: '',
+      linkToName: '',
+    };
+  },
+
+  mounted() {
+    if (this.isTargetPage(this.$page)) {
+      this.shouldShow = true;
+      this.date = this.$page.frontmatter.package_release.date;
+      this.name = this.$page.frontmatter.package_release.name;
+      this.linkToDate = this.linkForDate(this.$page.frontmatter.package_release.date);
+      this.linkToName = this.linkForName(this.$page.frontmatter.package_release.name);
+    }
+  },
+
+  methods: {
+    /**
+     * @param {Page} page
+     * @return {bool}
+     */
+    isTargetPage(page) {
+      return (
+        page.frontmatter.package_release &&
+        page.frontmatter.package_release.date &&
+        /^\d{4}\/\d{2}\/\d{2}$/.test(page.frontmatter.package_release.date) &&
+        page.frontmatter.package_release.name &&
+        page.frontmatter.package_release.version
+      );
+    },
+
+    /**
+     * @param {string} date
+     * @return {string}
+     */
+    linkForDate(date) {
+      return sprintf('/%s/%s/', 'release', this.dateForPath(date));
+    },
+
+    linkForName(name) {
+      return sprintf('/%s/%s/', 'release', name);
+    },
+
+    /**
+     * @param {string} date
+     * @return {string}
+     */
+    dateForPath(date) {
+      return date.replace(/\//g, '');
+    }
+  },
+};
+</script>
+
+<style lang="stylus" scoped>
+</style>

--- a/docs/.vuepress/plugins/playground-release-diary/enhanceAppFile.js
+++ b/docs/.vuepress/plugins/playground-release-diary/enhanceAppFile.js
@@ -1,0 +1,5 @@
+import PlaygroundReleaseDiaryBackLink from './components/PlaygroundReleaseDiaryBackLink';
+
+export default ({Vue}) => {
+  Vue.component('PlaygroundReleaseDiaryBackLink', PlaygroundReleaseDiaryBackLink);
+};

--- a/docs/.vuepress/plugins/playground-release-diary/index.js
+++ b/docs/.vuepress/plugins/playground-release-diary/index.js
@@ -5,6 +5,7 @@
  * @typedef {import('vuepress-types').PluginOptionAPI} PluginOptionAPI
  */
 
+const path = require('path');
 const sprintf = require('sprintf-js').sprintf;
 const PackageContainer = require('./package-container');
 
@@ -148,6 +149,17 @@ module.exports = (options, ctx) => {
 
   return {
     name: 'playground-release-diary',
+
+    enhanceAppFiles: [
+      path.resolve(__dirname, 'enhanceAppFile.js'),
+    ],
+
+    chainMarkdown(config) {
+      config
+        .plugin('vuepress-plugin-playground-release-diary')
+        .use(require('./markdown-it-plugin'));
+    },
+
     async additionalPages() {
       return await prepareDiaryPages();
     }

--- a/docs/.vuepress/plugins/playground-release-diary/markdown-it-plugin.js
+++ b/docs/.vuepress/plugins/playground-release-diary/markdown-it-plugin.js
@@ -1,0 +1,9 @@
+module.exports = (md) => {
+  md.core.ruler.push('vuepress_plugin_playground_release_diary_back_link', (state) => {
+    const token = new state.Token('html_block', '', 0);
+    token.content = '<PlaygroundReleaseDiaryBackLink/>';
+    token.block = true;
+
+    state.tokens.push(token);
+  });
+};


### PR DESCRIPTION
Inject back links of:

- date page (`/release/{YYYYMMDD}/`)
- package page (`/release/{package_name}/`)

Because of the difficulty to inject text into markdown content, append links at the bottom of the page.